### PR TITLE
Update operator-install.adoc to fix 404 on values.yaml link

### DIFF
--- a/docs/1.6/modules/en/partials/operator-install.adoc
+++ b/docs/1.6/modules/en/partials/operator-install.adoc
@@ -74,4 +74,4 @@ helm upgrade --create-namespace -n cattle-elemental-system --install --set image
 
 === Installation options
 
-There are a few options that can be set in the chart install but that is out of scope for this document. You can see all the values on the chart https://github.com/rancher/elemental-operator/blob/main/.obs/chartfile/operator/values.yaml[values.yaml].
+There are a few options that can be set in the chart install but that is out of scope for this document. You can see all the values on the chart https://github.com/rancher/elemental-operator/blob/main/.obs/chartfile/elemental-operator-helm/values.yaml[values.yaml].


### PR DESCRIPTION
In docs/1.6/modules/en/partials/operator-install.adoc, The link to values.yaml in the https://github.com/rancher/elemental-product-docs/blob/main/docs/1.6/modules/en/partials/operator-install.adoc#installation-options section is returning a 404. 

Current link: https://github.com/rancher/elemental-operator/blob/main/.obs/chartfile/operator/values.yaml

Working link: https://github.com/rancher/elemental-operator/blob/main/.obs/chartfile/elemental-operator-helm/values.yaml

Please doublecheck if this link should become versioned as for the 1.5 branch, the old link does work, but since we point to main, this does not work anymore. The main branch (and 1.6/1.7) are using the updated link.