### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+local:
+	mkdir -p tmp
+	npx antora --version
+	npx antora --stacktrace --log-format=pretty --log-level=info \
+		elemental-playbook-local.yml \
+		2>&1 | tee tmp/local-build.log 2>&1
+
+remote:
+	mkdir -p tmp
+	npm ci
+	npx antora --version
+	npx antora --stacktrace --log-format=pretty --log-level=info \
+		elemental-playbook-remote.yml \
+		2>&1 | tee tmp/remote-build.log 2>&1
+
+clean:
+	rm -rf build
+
+environment:
+	npm ci
+
+preview:
+	npx http-server build/site -c-1


### PR DESCRIPTION
Add a Makefile for convenience when running some commands. #33 also uses a make command because I thought it was present in this repo.

Note this PR [currently fails](https://github.com/rancher/elemental-product-docs/actions/runs/14918447382/job/41909078982?pr=35) because of existing WARN level build errors that #33 unveils.