### PR TITLE
Use attribute to remove redundancies in other attribute definitions

### DIFF
--- a/docs/1.5/antora.yml
+++ b/docs/1.5/antora.yml
@@ -8,21 +8,6 @@ nav:
 - modules/en/nav.adoc
 asciidoc:
   attributes:
-    # Elemental Docs Attributes
-    elemental_slack_name: '#elemental channel on the Rancher-Users Slack'
-    elemental_slack_url: https://rancher-users.slack.com/channels/elemental
-    elemental_toolkit_name: SUSE® Rancher Prime OS Manager Toolkit
-    elemental_toolkit_url: https://rancher.github.io/elemental-toolkit
-    elemental_operator_name: SUSE® Rancher Prime OS Manager Operator
-    elemental_operator_url: https://github.com/rancher/elemental-operator
-    elemental_cli_name: SUSE® Rancher Prime OS Manager CLI
-    elemental_cli_url: https://github.com/rancher/elemental-cli
-    elemental_ui_name: SUSE® Rancher Prime OS Manager UI plugin
-    elemental_ui_url: https://github.com/rancher/elemental-ui
-    elemental_iso_name: SUSE® Rancher Prime OS Manager ISO
-    elemental_register_name: SUSE® Rancher Prime OS Manager Register client
-    ranchersystemagent_name: Rancher System Agent
-    ranchersystemagent_url: https://github.com/rancher/system-agent
     # Product Names
     elemental-product-name: "SUSE® Rancher Prime: OS Manager"
     fleet-product-name: "SUSE® Rancher Prime: Continuous Delivery"
@@ -39,3 +24,19 @@ asciidoc:
     rke2-product-name: "SUSE® Rancher Prime: RKE2"
     rke2-short-name: "RKE2"
     turtles-product-name: "SUSE® Rancher Prime: Cluster API"
+    # Elemental Docs Attributes
+    elemental_slack_name: '#elemental channel on the Rancher-Users Slack'
+    elemental_slack_url: https://rancher-users.slack.com/channels/elemental
+    elemental_toolkit_name: '{elemental-product-name} Toolkit'
+    elemental_toolkit_url: https://rancher.github.io/elemental-toolkit
+    elemental_operator_name: '{elemental-product-name} Operator'
+    elemental_operator_url: https://github.com/rancher/elemental-operator
+    elemental_cli_name: '{elemental-product-name} CLI'
+    elemental_cli_url: https://github.com/rancher/elemental-cli
+    elemental_ui_name: '{elemental-product-name} UI plugin'
+    elemental_ui_url: https://github.com/rancher/elemental-ui
+    elemental_iso_name: '{elemental-product-name} ISO'
+    elemental_register_name: '{elemental-product-name} Register client'
+    ranchersystemagent_name: Rancher System Agent
+    ranchersystemagent_url: https://github.com/rancher/system-agent
+    

--- a/docs/1.6/antora.yml
+++ b/docs/1.6/antora.yml
@@ -8,21 +8,6 @@ nav:
 - modules/en/nav.adoc
 asciidoc:
   attributes:
-    # Elemental Docs Attributes
-    elemental_slack_name: '#elemental channel on the Rancher-Users Slack'
-    elemental_slack_url: https://rancher-users.slack.com/channels/elemental
-    elemental_toolkit_name: SUSE® Rancher Prime OS Manager Toolkit
-    elemental_toolkit_url: https://rancher.github.io/elemental-toolkit
-    elemental_operator_name: SUSE® Rancher Prime OS Manager Operator
-    elemental_operator_url: https://github.com/rancher/elemental-operator
-    elemental_cli_name: SUSE® Rancher Prime OS Manager CLI
-    elemental_cli_url: https://github.com/rancher/elemental-cli
-    elemental_ui_name: SUSE® Rancher Prime OS Manager UI plugin
-    elemental_ui_url: https://github.com/rancher/elemental-ui
-    elemental_iso_name: SUSE® Rancher Prime OS Manager ISO
-    elemental_register_name: SUSE® Rancher Prime OS Manager Register client
-    ranchersystemagent_name: Rancher System Agent
-    ranchersystemagent_url: https://github.com/rancher/system-agent
     # Product Names
     elemental-product-name: "SUSE® Rancher Prime: OS Manager"
     fleet-product-name: "SUSE® Rancher Prime: Continuous Delivery"
@@ -39,3 +24,19 @@ asciidoc:
     rke2-product-name: "SUSE® Rancher Prime: RKE2"
     rke2-short-name: "RKE2"
     turtles-product-name: "SUSE® Rancher Prime: Cluster API"
+    # Elemental Docs Attributes
+    elemental_slack_name: '#elemental channel on the Rancher-Users Slack'
+    elemental_slack_url: https://rancher-users.slack.com/channels/elemental
+    elemental_toolkit_name: '{elemental-product-name} Toolkit'
+    elemental_toolkit_url: https://rancher.github.io/elemental-toolkit
+    elemental_operator_name: '{elemental-product-name} Operator'
+    elemental_operator_url: https://github.com/rancher/elemental-operator
+    elemental_cli_name: '{elemental-product-name} CLI'
+    elemental_cli_url: https://github.com/rancher/elemental-cli
+    elemental_ui_name: '{elemental-product-name} UI plugin'
+    elemental_ui_url: https://github.com/rancher/elemental-ui
+    elemental_iso_name: '{elemental-product-name} ISO'
+    elemental_register_name: '{elemental-product-name} Register client'
+    ranchersystemagent_name: Rancher System Agent
+    ranchersystemagent_url: https://github.com/rancher/system-agent
+    


### PR DESCRIPTION
Before the changes in #40, the value of  `product-name: SUSE® Rancher Prime OS Manager` did not have a colon. A number of other attributes also followed this pattern, but currently the missing colon does not alight with the new definition ` elemental-product-name: "SUSE® Rancher Prime: OS Manager"`. The change to use `elemental-product-name` in the definitions of other attributes also addresses this.

Note, the order of the attribute groups needed to be switched as you can't use an attribute until it's defined.